### PR TITLE
Release 0.16.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "xLDCIyKDi4Vhl6K6smxQsOO2FDvsjLFIL8KbhxIrkXiFyNDbLutGVZb59hsJZHP1b9ca2EACIG/9aq23Kak1ctiD071O4893WrO/S9TdVz+XrFeIZOEdvxu3JpwTTzU+kXJjKkCTId7H3E8/awGzDTEPduUvJjjAcfeYypag6IJKpDxnBWrfdWAWcExXEm4vhn7H45NOU7noGY9icCmvugmjE2FcQkYueh+kta3nozBDpKU6/d9dmKrRnZgEbWifEGVDrd7cdSxPsAk7b54b4KwB+26c2t53n3S28Ux3iWzD6YfNmDetnCU3IQAsBpVBlL1tFfvmXMr2lzwW6kgf9XzToibd94c3sEX3M04qJQrzwgC408Meq6QI49DQYMIL9kuvcSG6zifhi+sr+qjL2IzGBNe4V0nblXyCJzlF0brORvyDxK4swlYH7zLlDDjhGwai9jIIrT8qWNfa36IXl7w7vGv5vs0H+P2h8Ame9/BAcmm28gfZdvZPlVvgV6kLOwpND+vAQ+dEwu4zYM2Di8RaP9xlF50zLucfFJTWkQylkZl1POeiChsAARVIrACP96kg/za1i3/7XSkYCmqO50KShVIV++cvjP/F7zHo0+8PKr5DKpeyFuZBjX2ofmceLJWQSE4L9ciEEnQINfVa8lLgg/xSwthElNTEo5/75+I="
@@ -25,9 +26,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Python 3. It allows you to use a single, clean Python 3.x-compatible
 codebase to support both Python 2 and Python 3 with minimal overhead.
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/future-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/future-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/future-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/future-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/future-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/future-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/future/badges/version.svg)](https://anaconda.org/conda-forge/future)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/future/badges/downloads.svg)](https://anaconda.org/conda-forge/future)
+
 Installing future
 =================
 
@@ -34,7 +46,6 @@ It is possible to list all of the versions of `future` available on your platfor
 ```
 conda search future --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -70,18 +81,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/future-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/future-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/future-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/future-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/future-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/future-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/future/badges/version.svg)](https://anaconda.org/conda-forge/future)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/future/badges/downloads.svg)](https://anaconda.org/conda-forge/future)
 
 
 Updating future-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,35 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +65,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -56,6 +56,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3d3b193f20ca62ba7d8782589922878820d0a023b885882deec830adbf639b97
+  sha256: {{ sha256 }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "future" %}
-{% set version = "0.15.2" %}
-{% set sha256 = "3d3b193f20ca62ba7d8782589922878820d0a023b885882deec830adbf639b97" %}
+{% set version = "0.16.0" %}
+{% set sha256 = "e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb" %}
 
 
 package:


### PR DESCRIPTION
`````` rst
What's new in version 0.16.0 (2016-10-27)
==========================================

This release removes the ``configparser`` package as an alias for
``ConfigParser`` on Py2 to improve compatibility with Lukasz Langa's
backported `configparser <https://pypi.python.org/configparser>`_ package.
Previously ``python-future`` and the ``configparser`` backport clashed,
causing various compatibility issues. (Issues #118, #181)

If your code previously relied on ``configparser`` being supplied by
``python-future``, the recommended upgrade path is to run ``pip install
configparser`` or add ``configparser`` to your ``requirements.txt`` file.

Note that, if you are upgrading ``future`` with ``pip``, you may need to
uninstall the old version of future or manually remove the
``site-packages/future-0.15.2-py2.7.egg`` folder for this change to take
effect on your system.

This releases also fixes these bugs:

- Fix ``newbytes`` constructor bug. (Issue #163)
- Fix semantics of ``bool()`` with ``newobject``. (Issue #211)
- Fix ``standard_library.install_aliases()`` on PyPy. (Issue #205)
- Fix assertRaises for ``pow`` and ``compile``` on Python 3.5. (Issue #183)
- Fix return argument of ``future.utils.ensure_new_type`` if conversion to
  new type does not exist. (Issue #185)
- Add missing ``cmp_to_key`` for Py2.6. (Issue #189)
- Allow the ``old_div`` fixer to be disabled. (Issue #190)
- Improve compatibility with Google App Engine. (Issue #231)
- Add some missing imports to the ``tkinter`` and ``tkinter.filedialog``
  package namespaces. (Issues #212 and #233)
- More complete implementation of ``raise_from`` on PY3. (Issues #141,
  #213 and #235, fix provided by Varriount)
``````

xref: http://python-future.org/whatsnew.html#what-s-new-in-version-0-16-0-2016-10-27
